### PR TITLE
Feature/filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,11 @@ run-mosquitto:
 test: unit-test integration-test
 
 unit-test:
+ifeq ($(REGEX),)
 	pytest -vvv --log-level=INFO -m unit
+else
+	pytest -vvvv --log-level=INFO -s -m unit -k $(REGEX)
+endif
 
 integration-test:
 ifeq ($(REGEX),)

--- a/config.yaml
+++ b/config.yaml
@@ -78,7 +78,7 @@ i2c_optoisolated_inputs:
       # this means that any transition 0->1 or 1->0 shorter than 6secs will be ignored
       # it also means that the sensor changes will appear to HomeAssistant with a delay
       # of the same amount of seconds
-      minimal_duration_sec: 6
+      stability_threshold_sec: 6
   - name: opto_input_2
     description: Opto-isolated Input for Sensor BCD
     input_num: 2

--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,11 @@ i2c_optoisolated_inputs:
       device_class: motion
       expire_after: 30
       icon: mdi:motion-sensor
+    filter:
+      # this means that any transition 0->1 or 1->0 shorter than 6secs will be ignored
+      # it also means that the sensor changes will appear to HomeAssistant with a delay
+      # of the same amount of seconds
+      minimal_duration_sec: 6
   - name: opto_input_2
     description: Opto-isolated Input for Sensor BCD
     input_num: 2

--- a/raspy2mqtt/circular_buffer.py
+++ b/raspy2mqtt/circular_buffer.py
@@ -97,16 +97,16 @@ class CircularBuffer:
             sample_age_sec = last_ts - s[0]
             if sample_age_sec >= min_stability_sec:
                 # debug only:
-                #print(
+                # print(
                 #    f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> STABLE for threshold {min_stability_sec}"
-                #)
+                # )
                 # found a stable sample!
                 return s
 
             # debug only:
-            #print(
+            # print(
             #    f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> UNSTABLE for threshold {min_stability_sec}"
-            #)
+            # )
 
             # keep going backward
             sample_offset_in_the_past += 1

--- a/raspy2mqtt/circular_buffer.py
+++ b/raspy2mqtt/circular_buffer.py
@@ -13,12 +13,45 @@
 
 
 class CircularBuffer:
+    """
+    This is a specialized implementation of a circular buffer designed to:
+    * hold boolean/digital samples
+    * hold non-uniformly-distributed samples: each sample has its companion timestamp and
+      there is no fixed sampling frequency assumption
+    * hold in the buffer only CHANGES in value: pushing twice the same value into the buffer
+      (with different timestamps) means the second sample is merged with the first one
+    * allow simple & efficient filtering for "stable" values discarding transient fluctuations
+      if their duration is below a fixed threshold
+    """
+
     def __init__(self, size: int):
+        assert size > 0
         self.size = size
-        self.buffer = [(None, None)] * size  # buffer is empty at the start
+        # buffer is empty at the start
+        # each entry is actually a tuple (TIMESTAMP;VALUE)
+        self.buffer = [(None, None)] * size
         self.index = 0  # next writable location in the buffer
+        self.last_timestamp = 0
 
     def push_sample(self, timestamp: int, value: bool) -> None:
+        # timestamp handling
+        if timestamp > self.last_timestamp:
+            assert timestamp > 0
+            self.last_timestamp = timestamp
+        else:
+            # fix invalid timestamp (NTP adjustment?)
+            self.last_timestamp += 1
+            timestamp = self.last_timestamp
+
+        # check if this is a value transition
+        if self.index > 0:
+            last_index = (self.index - 1) % self.size
+            if self.buffer[last_index][1] == value:
+                # not a transition... just discard the new sample -- it brings no information actually
+                # (to be fair: it provides the information that the value is STILL the same... but this
+                #  is assumed implicitly to be the case when no new samples are present)
+                return
+
         self.buffer[self.index % self.size] = (timestamp, value)
         self.index += 1
 
@@ -31,11 +64,57 @@ class CircularBuffer:
         return self.buffer[idx_mod:] + self.buffer[:idx_mod]  # linearize the circular buffer
 
     def get_last_sample(self) -> tuple:
+        r = self.get_past_sample(1)  # look 1 sample in the past, which means the last pushed sample
+        if r is None:
+            return None
+        # r[0] contains the index inside this buffer, which the caller typically don't care about
+        return r[1]
+
+    def get_past_sample(self, sample_offset_in_the_past: int) -> tuple:
         if self.index == 0:
             return None  # buffer is empty
-        last_index = (self.index - 1) % self.size
-        return self.buffer[last_index]
+        if self.index < sample_offset_in_the_past:
+            # the caller is requesting a sample too much in the past -- beyond the buffer memory
+            return None
+        if sample_offset_in_the_past < 1:
+            # sample_offset_in_the_past==0 (or negative) is not a sample in the past
+            return None
+        if sample_offset_in_the_past > self.size:
+            # the caller is trying to explore too much in the past -- beyond the buffer memory
+            return None
+        last_index = (self.index - sample_offset_in_the_past) % self.size
+        return (last_index, self.buffer[last_index])
 
+    def get_stable_sample(self, now_ts: int, min_stability_sec: float) -> tuple:
+        if self.index == 0:
+            return None  # buffer is empty
+        if now_ts < self.last_timestamp:
+            # fix invalid timestamp (NTP adjustment?)
+            now_ts = self.last_timestamp
+        # starting from the last sample search going backwards the first "stable" sample:
+        last_ts = now_ts
+        sample_offset_in_the_past = 1
+        while sample_offset_in_the_past <= self.size:
+            r = self.get_past_sample(sample_offset_in_the_past)
+            assert r is not None
+
+            idx = r[0]  # index
+            s = r[1]  # sample tuple (TIMESTAMP;VALUE)
+
+            sample_age_sec = last_ts - s[0]
+            if sample_age_sec >= min_stability_sec:
+                print(f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> STABLE for threshold {min_stability_sec}")
+                return s
+            
+            print(f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> UNSTABLE for threshold {min_stability_sec}")
+
+            # keep going backward
+            sample_offset_in_the_past += 1
+            last_ts = s[0]
+        
+        # the whole buffer has been inspected but all value transitions were shorter than 'min_stability_sec'
+        return None
+    
     def clear(self) -> None:
         self.buffer = [(None, None)] * self.size
         self.index = 0

--- a/raspy2mqtt/circular_buffer.py
+++ b/raspy2mqtt/circular_buffer.py
@@ -96,14 +96,17 @@ class CircularBuffer:
 
             sample_age_sec = last_ts - s[0]
             if sample_age_sec >= min_stability_sec:
-                print(
-                    f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> STABLE for threshold {min_stability_sec}"
-                )
+                # debug only:
+                #print(
+                #    f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> STABLE for threshold {min_stability_sec}"
+                #)
+                # found a stable sample!
                 return s
 
-            print(
-                f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> UNSTABLE for threshold {min_stability_sec}"
-            )
+            # debug only:
+            #print(
+            #    f"sample_offset_in_the_past={sample_offset_in_the_past} -> sample_age_sec={sample_age_sec} -> UNSTABLE for threshold {min_stability_sec}"
+            #)
 
             # keep going backward
             sample_offset_in_the_past += 1

--- a/raspy2mqtt/circular_buffer.py
+++ b/raspy2mqtt/circular_buffer.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#
+# Author: fmontorsi
+# Created: June 2024
+# License: Apache license
+#
+
+
+# =======================================================================================================
+# CircularBuffer
+# =======================================================================================================
+
+class CircularBuffer:
+    def __init__(self, size: int):
+        self.size = size
+        self.buffer = [(None, None)] * size  # buffer is empty at the start
+        self.index = 0  # next writable location in the buffer
+
+    def push_sample(self, timestamp: int, value: bool) -> None:
+        self.buffer[self.index % self.size] = (timestamp, value)
+        self.index += 1
+
+    def get_all_samples(self) -> list:
+        if self.index == 0:
+            return None  # buffer is empty
+        if self.index <= self.size:
+            return self.buffer[: self.index]  # return only valid/populated items
+        idx_mod = self.index % self.size
+        return self.buffer[idx_mod:] + self.buffer[:idx_mod]  # linearize the circular buffer
+
+    def get_last_sample(self) -> tuple:
+        if self.index == 0:
+            return None  # buffer is empty
+        last_index = (self.index - 1) % self.size
+        return self.buffer[last_index]
+
+    def clear(self) -> None:
+        self.buffer = [(None, None)] * self.size
+        self.index = 0

--- a/raspy2mqtt/circular_buffer.py
+++ b/raspy2mqtt/circular_buffer.py
@@ -92,7 +92,9 @@ class CircularBuffer:
         sample_offset_in_the_past = 1
         while sample_offset_in_the_past <= self.size:
             s = self.get_past_sample(sample_offset_in_the_past)
-            assert s is not None
+            if s is None:
+                # trying to dig too much into the past... perhaps the circular buffer is not completely full yet...
+                return None
 
             sample_age_sec = last_ts - s[0]
             if sample_age_sec >= min_stability_sec:

--- a/raspy2mqtt/circular_buffer.py
+++ b/raspy2mqtt/circular_buffer.py
@@ -11,6 +11,7 @@
 # CircularBuffer
 # =======================================================================================================
 
+
 class CircularBuffer:
     def __init__(self, size: int):
         self.size = size

--- a/raspy2mqtt/config.py
+++ b/raspy2mqtt/config.py
@@ -243,7 +243,9 @@ class AppConfig:
                 self.config["i2c_optoisolated_inputs"] = []
 
             for input_item in self.config["i2c_optoisolated_inputs"]:
-                input_item = self.populate_defaults_in_list_entry(input_item, has_state_topic=False, is_output=False)
+                input_item = self.populate_defaults_in_list_entry(
+                    input_item, has_state_topic=False, is_output=False, populate_filter=True
+                )
 
                 # check GPIO index
                 idx = int(input_item["input_num"])
@@ -298,6 +300,7 @@ class AppConfig:
                     has_payload_on_off=False,
                     has_state_topic=False,
                     is_output=False,
+                    populate_filter=False,  # GPIO inputs do not support filtering at this time
                 )
 
                 # check GPIO index
@@ -331,7 +334,12 @@ class AppConfig:
                 self.config["outputs"] = []
 
             for output_item in self.config["outputs"]:
-                output_item = self.populate_defaults_in_list_entry(output_item)
+
+                output_item = self.populate_defaults_in_list_entry(
+                    output_item,
+                    is_output=True,
+                    populate_filter=False,  # filtering does not make sense for outputs
+                )
 
                 # check GPIO index
                 idx = int(output_item["gpio"])

--- a/raspy2mqtt/config.py
+++ b/raspy2mqtt/config.py
@@ -211,7 +211,8 @@ class AppConfig:
             # filtering the output does not make sense, so the filter parameter is allowed only for inputs
             if "filter" not in entry_dict:
                 entry_dict["filter"] = {}
-
+            if "minimal_duration_sec" not in entry_dict["filter"]:
+                entry_dict["filter"]["minimal_duration_sec"] = 0  # 0 means filtering is disabled
         return entry_dict
 
     def load(self, cfg_yaml: str) -> bool:

--- a/raspy2mqtt/config.py
+++ b/raspy2mqtt/config.py
@@ -82,6 +82,12 @@ class AppConfig:
             }
         )
 
+        self.filter_schema = Schema(
+            {
+                Optional("minimal_duration_sec"): int,
+            }
+        )
+
         self.config_file_schema = Schema(
             {
                 "mqtt_broker": {
@@ -109,6 +115,7 @@ class AppConfig:
                         "active_low": bool,
                         Optional("mqtt"): self.mqtt_schema_for_sensor_on_and_off,
                         "home_assistant": self.home_assistant_schema,
+                        Optional("filter"): self.filter_schema,
                     }
                 ],
                 Optional("gpio_inputs"): [
@@ -160,6 +167,7 @@ class AppConfig:
         has_payload_on_off: bool = True,
         has_state_topic: bool = True,
         is_output: bool = True,
+        populate_filter: bool = True,
     ) -> dict:
         if "description" not in entry_dict:
             entry_dict["description"] = entry_dict["name"]
@@ -198,6 +206,11 @@ class AppConfig:
                 entry_dict["home_assistant"]["icon"] = None
             if "platform" not in entry_dict["home_assistant"]:
                 entry_dict["home_assistant"]["platform"] = "switch" if is_output else "binary_sensor"
+
+        if populate_filter and not is_output:
+            # filtering the output does not make sense, so the filter parameter is allowed only for inputs
+            if "filter" not in entry_dict:
+                entry_dict["filter"] = {}
 
         return entry_dict
 

--- a/raspy2mqtt/config.py
+++ b/raspy2mqtt/config.py
@@ -84,7 +84,7 @@ class AppConfig:
 
         self.filter_schema = Schema(
             {
-                Optional("minimal_duration_sec"): int,
+                Optional("stability_threshold_sec"): int,
             }
         )
 
@@ -211,8 +211,8 @@ class AppConfig:
             # filtering the output does not make sense, so the filter parameter is allowed only for inputs
             if "filter" not in entry_dict:
                 entry_dict["filter"] = {}
-            if "minimal_duration_sec" not in entry_dict["filter"]:
-                entry_dict["filter"]["minimal_duration_sec"] = 0  # 0 means filtering is disabled
+            if "stability_threshold_sec" not in entry_dict["filter"]:
+                entry_dict["filter"]["stability_threshold_sec"] = 0  # 0 means filtering is disabled
         return entry_dict
 
     def load(self, cfg_yaml: str) -> bool:

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -135,6 +135,7 @@ class OptoIsolatedInputsHandler:
                     while not OptoIsolatedInputsHandler.stop_requested:
                         # Publish each sampled value as a separate MQTT topic
                         update_loop_start_sec = time.perf_counter()
+                        timestamp_now = int(time.time())
                         for i in range(SeqMicroHatConstants.MAX_CHANNELS):
                             # convert from zero-based index 'i' to 1-based index, as used in the config file
                             input_cfg = cfg.get_optoisolated_input_config(1 + i)
@@ -150,7 +151,7 @@ class OptoIsolatedInputsHandler:
                                 else:
                                     # filtering enabled -- choose sensor status:
                                     bit_value = self.optoisolated_inputs_sampled_values[i].get_stable_sample(
-                                        filter_min_duration
+                                        timestamp_now, filter_min_duration
                                     )[1]
 
                             if input_cfg["active_low"]:

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -149,7 +149,7 @@ class OptoIsolatedInputsHandler:
                                     bit_value = self.optoisolated_inputs_sampled_values[i].get_last_sample()[1]
                                 else:
                                     # filtering enabled -- choose sensor status:
-                                    bit_value = self.optoisolated_inputs_sampled_values[i].get_last_sample()[1]
+                                    bit_value = self.optoisolated_inputs_sampled_values[i].get_stable_sample(filter_min_duration)[1]
 
                             if input_cfg["active_low"]:
                                 logical_value = not bit_value

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -194,7 +194,7 @@ class OptoIsolatedInputsHandler:
                 self.stats["ERROR_num_connections_lost"] += 1
                 await asyncio.sleep(cfg.mqtt_reconnection_period_sec)
             except Exception as err:
-                print(f"EXCEPTION: {err}")
+                print(f"EXCEPTION: [{err}]. Exiting with code 99.")
                 sys.exit(99)
 
     async def homeassistant_discovery_message_publish(self, cfg: AppConfig):
@@ -251,4 +251,5 @@ class OptoIsolatedInputsHandler:
         print(">>   OPTO-ISOLATED DISCOVERY messages:")
         print(f">>     Num MQTT discovery messages published: {self.stats['num_mqtt_discovery_messages_published']}")
         print(f">>     Num (re)connections to the MQTT broker: {self.stats['num_connections_discovery_publish']}")
+        print(f">>   ERROR: unstable samples found: {self.stats['ERROR_no_stable_samples']}")
         print(f">>   ERROR: MQTT connections lost: {self.stats['ERROR_num_connections_lost']}")

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -11,6 +11,7 @@ import threading
 from raspy2mqtt.constants import MqttQOS, SeqMicroHatConstants
 from raspy2mqtt.config import AppConfig
 from raspy2mqtt.circular_buffer import CircularBuffer
+
 #
 # Author: fmontorsi
 # Created: May 2024

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -10,8 +10,6 @@ import aiomqtt
 import threading
 from raspy2mqtt.constants import MqttQOS, SeqMicroHatConstants
 from raspy2mqtt.config import AppConfig
-from collections import deque
-
 
 #
 # Author: fmontorsi
@@ -20,16 +18,16 @@ from collections import deque
 #
 
 
-
 # =======================================================================================================
 # CircularBuffer
 # =======================================================================================================
+
 
 class CircularBuffer:
     def __init__(self, size):
         self.size = size
         self.buffer = [(None, None)] * size  # buffer is empty at the start
-        self.index = 0 # next writable location in the buffer
+        self.index = 0  # next writable location in the buffer
         self.is_full = False
 
     def add_sample(self, timestamp, value):
@@ -41,8 +39,8 @@ class CircularBuffer:
 
     def get_samples(self):
         if not self.is_full:
-            return self.buffer[:self.index]  # Restituisce solo gli elementi validi
-        return self.buffer[self.index:] + self.buffer[:self.index]  # Restituisce gli elementi in ordine circolare
+            return self.buffer[: self.index]  # Restituisce solo gli elementi validi
+        return self.buffer[self.index :] + self.buffer[: self.index]  # Restituisce gli elementi in ordine circolare
 
     def get_last_sample(self):
         if not self.is_full and self.index == 0:
@@ -54,7 +52,6 @@ class CircularBuffer:
         self.buffer = [(None, None)] * self.size
         self.index = 0
         self.is_full = False
-
 
 
 # =======================================================================================================

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -149,7 +149,9 @@ class OptoIsolatedInputsHandler:
                                     bit_value = self.optoisolated_inputs_sampled_values[i].get_last_sample()[1]
                                 else:
                                     # filtering enabled -- choose sensor status:
-                                    bit_value = self.optoisolated_inputs_sampled_values[i].get_stable_sample(filter_min_duration)[1]
+                                    bit_value = self.optoisolated_inputs_sampled_values[i].get_stable_sample(
+                                        filter_min_duration
+                                    )[1]
 
                             if input_cfg["active_low"]:
                                 logical_value = not bit_value

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -10,47 +10,12 @@ import aiomqtt
 import threading
 from raspy2mqtt.constants import MqttQOS, SeqMicroHatConstants
 from raspy2mqtt.config import AppConfig
-
+from raspy2mqtt.circular_buffer import CircularBuffer
 #
 # Author: fmontorsi
 # Created: May 2024
 # License: Apache license
 #
-
-
-# =======================================================================================================
-# CircularBuffer
-# =======================================================================================================
-
-
-class CircularBuffer:
-    def __init__(self, size: int):
-        self.size = size
-        self.buffer = [(None, None)] * size  # buffer is empty at the start
-        self.index = 0  # next writable location in the buffer
-
-    def push_sample(self, timestamp: int, value: bool) -> None:
-        self.buffer[self.index % self.size] = (timestamp, value)
-        self.index += 1
-
-    def get_all_samples(self) -> list:
-        if self.index == 0:
-            return None  # buffer is empty
-        if self.index <= self.size:
-            return self.buffer[: self.index]  # return only valid/populated items
-        idx_mod = self.index % self.size
-        return self.buffer[idx_mod:] + self.buffer[:idx_mod]  # linearize the circular buffer
-
-    def get_last_sample(self) -> tuple:
-        if self.index == 0:
-            return None  # buffer is empty
-        last_index = (self.index - 1) % self.size
-        return self.buffer[last_index]
-
-    def clear(self) -> None:
-        self.buffer = [(None, None)] * self.size
-        self.index = 0
-
 
 # =======================================================================================================
 # OptoIsolatedInputsHandler

--- a/raspy2mqtt/optoisolated_inputs_handler.py
+++ b/raspy2mqtt/optoisolated_inputs_handler.py
@@ -143,7 +143,7 @@ class OptoIsolatedInputsHandler:
 
                             # acquire last sampled value for the i-th input
                             with self.lock:
-                                filter_min_duration = input_cfg["filter"]["minimal_duration_sec"]
+                                filter_min_duration = input_cfg["filter"]["stability_threshold_sec"]
                                 if filter_min_duration == 0:
                                     # filtering disabled -- just pick the most updated sample and use it
                                     bit_value = self.optoisolated_inputs_sampled_values[i].get_last_sample()[1]

--- a/systemd/rpi2home-assistant.service
+++ b/systemd/rpi2home-assistant.service
@@ -21,6 +21,9 @@ Environment="GPIOZERO_PIN_FACTORY=pigpio"
 Environment=PYTHONUNBUFFERED=1
 Restart=on-failure
 RestartSec=5s
- 
+
+# the time between a graceful SIGTERM and the brute SIGKILL:
+TimeoutStopSec=5
+
 [Install]
 WantedBy=multi-user.target

--- a/tests/mosquitto_container.py
+++ b/tests/mosquitto_container.py
@@ -40,7 +40,7 @@ class MosquittoContainer(DockerContainer):
         self.password = password
 
         # setup container:
-        self.with_bind_ports(self.port, self.port)
+        self.with_exposed_ports(self.port, self.port)
         if configfile is None:
             # default config ifle
             TEST_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/mosquitto_container.py
+++ b/tests/mosquitto_container.py
@@ -40,7 +40,7 @@ class MosquittoContainer(DockerContainer):
         self.password = password
 
         # setup container:
-        self.with_exposed_ports(self.port, self.port)
+        self.with_exposed_ports(self.port)
         if configfile is None:
             # default config ifle
             TEST_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -6,51 +6,156 @@ from raspy2mqtt.circular_buffer import CircularBuffer
 @pytest.mark.unit
 def test_circbuf_push_sample():
     circular_buffer = CircularBuffer(3)
-    circular_buffer.push_sample(int(time.time()), 10)
-    circular_buffer.push_sample(int(time.time()), 20)
-    circular_buffer.push_sample(int(time.time()), 30)
+    circular_buffer.push_sample(int(time.time()), False)
+    circular_buffer.push_sample(int(time.time()), True)
+    circular_buffer.push_sample(int(time.time()), False)
     samples = circular_buffer.get_all_samples()
     assert len(samples) == 3
-    assert samples[0][1] == 10
-    assert samples[1][1] == 20
-    assert samples[2][1] == 30
+    assert samples[0][1] == False
+    assert samples[1][1] == True
+    assert samples[2][1] == False
+
+
+@pytest.mark.unit
+def test_circbuf_push_sample_wrong_ts():
+    circular_buffer = CircularBuffer(3)
+    circular_buffer.push_sample(100, False)
+    circular_buffer.push_sample(99, True)
+    circular_buffer.push_sample(98, False)
+    samples = circular_buffer.get_all_samples()
+    assert len(samples) == 3
+    assert samples[0] == (100, False)
+    assert samples[1] == (101, True)  # timestamp has been fixed
+    assert samples[2] == (102, False)  # timestamp has been fixed
 
 
 @pytest.mark.unit
 def test_circbuf_circular_behavior():
     circular_buffer = CircularBuffer(3)
-    circular_buffer.push_sample(int(time.time()), 10)
-    circular_buffer.push_sample(int(time.time()), 20)
-    circular_buffer.push_sample(int(time.time()), 30)
-    circular_buffer.push_sample(int(time.time()), 40)
-    circular_buffer.push_sample(int(time.time()), 50)
+    circular_buffer.push_sample(int(time.time()), False)
+    circular_buffer.push_sample(int(time.time()), True)
+    circular_buffer.push_sample(int(time.time()), False)
+    circular_buffer.push_sample(int(time.time()), True)
+    circular_buffer.push_sample(int(time.time()), False)
     samples = circular_buffer.get_all_samples()
     assert len(samples) == 3
-    assert samples[0][1] == 30
-    assert samples[1][1] == 40
-    assert samples[2][1] == 50
+    assert samples[0][1] == False
+    assert samples[1][1] == True
+    assert samples[2][1] == False
+
+
+@pytest.mark.unit
+def test_circbuf_push_sample_merge_behavior():
+    circular_buffer = CircularBuffer(3)
+    circular_buffer.push_sample(100, False)
+    circular_buffer.push_sample(101, False)
+    circular_buffer.push_sample(102, False)
+    circular_buffer.push_sample(103, False)
+    circular_buffer.push_sample(104, True)
+    # many samples but just 1 transition, so we expect 2 samples into the buffer:
+    samples = circular_buffer.get_all_samples()
+    assert len(samples) == 2
+    assert samples[0] == (100, False)
+    assert samples[1] == (104, True)
+    # add 1 more transition, so we can now expect 3 samples into the buffer:
+    circular_buffer.push_sample(105, False)
+    samples = circular_buffer.get_all_samples()
+    assert len(samples) == 3
+    assert samples[0] == (100, False)
+    assert samples[1] == (104, True)
+    assert samples[2] == (105, False)
 
 
 @pytest.mark.unit
 def test_circbuf_get_last_sample():
     circular_buffer = CircularBuffer(3)
     assert circular_buffer.get_last_sample() == None
-    circular_buffer.push_sample(int(time.time()), 10)
-    circular_buffer.push_sample(int(time.time()), 20)
-    assert circular_buffer.get_last_sample()[1] == 20
-    circular_buffer.push_sample(int(time.time()), 30)
-    circular_buffer.push_sample(int(time.time()), 40)
-    circular_buffer.push_sample(int(time.time()), 50)
-    assert circular_buffer.get_last_sample()[1] == 50
-    circular_buffer.push_sample(int(time.time()), 60)
-    assert circular_buffer.get_last_sample()[1] == 60
+    circular_buffer.push_sample(1, False)
+    circular_buffer.push_sample(2, True)
+    assert circular_buffer.get_last_sample() == (2, True)
+    circular_buffer.push_sample(3, False)
+    circular_buffer.push_sample(4, False)
+    circular_buffer.push_sample(5, True)
+    assert circular_buffer.get_last_sample() == (5, True)
+    circular_buffer.push_sample(6, False)
+    assert circular_buffer.get_last_sample() == (6, False)
 
+
+@pytest.mark.unit
+def test_circbuf_get_past_sample():
+    circular_buffer = CircularBuffer(3)
+    assert circular_buffer.get_past_sample(1) == None
+    circular_buffer.push_sample(10, False)
+    circular_buffer.push_sample(20, True)
+    circular_buffer.push_sample(30, False)
+    circular_buffer.push_sample(40, False)  # this sample gets merged with previous one
+    circular_buffer.push_sample(50, True)
+    # the internal buffer status is expected to be:
+    #
+    #   index|timestamp|value
+    #   0    |50       |True          <-- this entry was initially (10, False) but then gets overwritten
+    #   1    |20       |True
+    #   2    |30       |False         <-- this entry has absorbed/was-merged with the entry (40, False)
+    #
+    #   circular_buffer.index = next writable entry = 1
+    #
+    # note that the first sample (1,False) has been "forgot" -- too old compared to the buffer memory of 3 transitions
+    assert circular_buffer.get_past_sample(1) == (0, (50, True))
+    assert circular_buffer.get_past_sample(2) == (2, (30, False))
+    assert circular_buffer.get_past_sample(3) == (1, (20, True))
+    assert circular_buffer.get_past_sample(4) == None
+
+
+@pytest.mark.unit
+def test_circbuf_get_stable_sample1():
+    circular_buffer = CircularBuffer(3)
+    # lots of value transitions in a narrow time window [10s-50s] and then a final state transition after +40sec
+    circular_buffer.push_sample(10, False)
+    circular_buffer.push_sample(20, True)
+    circular_buffer.push_sample(30, False)
+    circular_buffer.push_sample(40, False)  # this sample gets merged with previous one
+    circular_buffer.push_sample(50, True)
+    circular_buffer.push_sample(60, True)  # this sample gets merged with previous one
+    circular_buffer.push_sample(90, False)
+
+    now_ts = 90 + 5
+    # if we ask at +5sec since last sample, a sample stable for at least 1sec, we'll get the last sample
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=1) == (90, False)
+    # if we ask at +5sec since last sample, a sample stable for at least 10sec, we'll get the penultimate sample
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=10) == (50, True)
+    # if we ask at +5sec since last sample, a sample stable for at least 50sec, we will find none
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=50) == None
+
+    # if we ask at +15sec since last sample, a sample stable for at least 14.5sec, we'll get the last asmple
+    now_ts = 90 + 15
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=14.5) == (90, False)
+    # if we ask at +15sec since last sample, a sample stable for at least 15.1sec, we'll get the penultimate sample
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=15.1) == (50, True)
+
+
+@pytest.mark.unit
+def test_circbuf_get_stable_sample2():
+    circular_buffer = CircularBuffer(10)
+    # a stable value for a lot of time, then a lot of quick transitions in the time window [50s-60s]
+    circular_buffer.push_sample(1, False)
+    circular_buffer.push_sample(50, True)
+    circular_buffer.push_sample(51, False)
+    circular_buffer.push_sample(52, True)
+    circular_buffer.push_sample(53, False)
+    circular_buffer.push_sample(56, True)
+    circular_buffer.push_sample(60, False)
+
+    now_ts = 60 + 1
+    # if we ask at +1sec since last sample, a sample stable for at least 2sec, we'll get the penultimate sample
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=2) == (56, True)
+    # if we ask at +1sec since last sample, a sample stable for at least 5sec, we'll get back to the very first sample...
+    assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=5) == (1, False)
 
 @pytest.mark.unit
 def test_circbuf_clear():
     circular_buffer = CircularBuffer(3)
-    circular_buffer.push_sample(int(time.time()), 10)
-    circular_buffer.push_sample(int(time.time()), 20)
+    circular_buffer.push_sample(int(time.time()), False)
+    circular_buffer.push_sample(int(time.time()), True)
     circular_buffer.clear()
     assert circular_buffer.get_all_samples() == None
     assert circular_buffer.get_last_sample() == None

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -2,6 +2,7 @@ import pytest
 import time
 from raspy2mqtt.optoisolated_inputs_handler import CircularBuffer
 
+
 @pytest.mark.unit
 def test_circbuf_push_sample():
     circular_buffer = CircularBuffer(3)
@@ -13,6 +14,7 @@ def test_circbuf_push_sample():
     assert samples[0][1] == 10
     assert samples[1][1] == 20
     assert samples[2][1] == 30
+
 
 @pytest.mark.unit
 def test_circbuf_circular_behavior():
@@ -28,6 +30,7 @@ def test_circbuf_circular_behavior():
     assert samples[1][1] == 40
     assert samples[2][1] == 50
 
+
 @pytest.mark.unit
 def test_circbuf_get_last_sample():
     circular_buffer = CircularBuffer(3)
@@ -41,6 +44,7 @@ def test_circbuf_get_last_sample():
     assert circular_buffer.get_last_sample()[1] == 50
     circular_buffer.push_sample(int(time.time()), 60)
     assert circular_buffer.get_last_sample()[1] == 60
+
 
 @pytest.mark.unit
 def test_circbuf_clear():

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -1,0 +1,52 @@
+import pytest
+import time
+from raspy2mqtt.optoisolated_inputs_handler import CircularBuffer
+
+@pytest.mark.unit
+def test_circbuf_push_sample():
+    circular_buffer = CircularBuffer(3)
+    circular_buffer.push_sample(int(time.time()), 10)
+    circular_buffer.push_sample(int(time.time()), 20)
+    circular_buffer.push_sample(int(time.time()), 30)
+    samples = circular_buffer.get_all_samples()
+    assert len(samples) == 3
+    assert samples[0][1] == 10
+    assert samples[1][1] == 20
+    assert samples[2][1] == 30
+
+@pytest.mark.unit
+def test_circbuf_circular_behavior():
+    circular_buffer = CircularBuffer(3)
+    circular_buffer.push_sample(int(time.time()), 10)
+    circular_buffer.push_sample(int(time.time()), 20)
+    circular_buffer.push_sample(int(time.time()), 30)
+    circular_buffer.push_sample(int(time.time()), 40)
+    circular_buffer.push_sample(int(time.time()), 50)
+    samples = circular_buffer.get_all_samples()
+    assert len(samples) == 3
+    assert samples[0][1] == 30
+    assert samples[1][1] == 40
+    assert samples[2][1] == 50
+
+@pytest.mark.unit
+def test_circbuf_get_last_sample():
+    circular_buffer = CircularBuffer(3)
+    assert circular_buffer.get_last_sample() == None
+    circular_buffer.push_sample(int(time.time()), 10)
+    circular_buffer.push_sample(int(time.time()), 20)
+    assert circular_buffer.get_last_sample()[1] == 20
+    circular_buffer.push_sample(int(time.time()), 30)
+    circular_buffer.push_sample(int(time.time()), 40)
+    circular_buffer.push_sample(int(time.time()), 50)
+    assert circular_buffer.get_last_sample()[1] == 50
+    circular_buffer.push_sample(int(time.time()), 60)
+    assert circular_buffer.get_last_sample()[1] == 60
+
+@pytest.mark.unit
+def test_circbuf_clear():
+    circular_buffer = CircularBuffer(3)
+    circular_buffer.push_sample(int(time.time()), 10)
+    circular_buffer.push_sample(int(time.time()), 20)
+    circular_buffer.clear()
+    assert circular_buffer.get_all_samples() == None
+    assert circular_buffer.get_last_sample() == None

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -2,6 +2,7 @@ import pytest
 import time
 from raspy2mqtt.circular_buffer import CircularBuffer
 
+
 @pytest.mark.unit
 def test_circbuf_push_sample():
     circular_buffer = CircularBuffer(3)

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -1,7 +1,6 @@
 import pytest
 import time
-from raspy2mqtt.optoisolated_inputs_handler import CircularBuffer
-
+from raspy2mqtt.circular_buffer import CircularBuffer
 
 @pytest.mark.unit
 def test_circbuf_push_sample():

--- a/tests/test_circular_buffer.py
+++ b/tests/test_circular_buffer.py
@@ -100,9 +100,9 @@ def test_circbuf_get_past_sample():
     #   circular_buffer.index = next writable entry = 1
     #
     # note that the first sample (1,False) has been "forgot" -- too old compared to the buffer memory of 3 transitions
-    assert circular_buffer.get_past_sample(1) == (0, (50, True))
-    assert circular_buffer.get_past_sample(2) == (2, (30, False))
-    assert circular_buffer.get_past_sample(3) == (1, (20, True))
+    assert circular_buffer.get_past_sample(1) == (50, True)
+    assert circular_buffer.get_past_sample(2) == (30, False)
+    assert circular_buffer.get_past_sample(3) == (20, True)
     assert circular_buffer.get_past_sample(4) == None
 
 
@@ -150,6 +150,7 @@ def test_circbuf_get_stable_sample2():
     assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=2) == (56, True)
     # if we ask at +1sec since last sample, a sample stable for at least 5sec, we'll get back to the very first sample...
     assert circular_buffer.get_stable_sample(now_ts, min_stability_sec=5) == (1, False)
+
 
 @pytest.mark.unit
 def test_circbuf_clear():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,7 @@ def test_config_file_using_defaults_succeeds(tmpdir):
     assert x.get_optoisolated_input_config(1) == {
         "active_low": True,
         "description": "opto_input_1",
+        "filter": {},
         "home_assistant": {"device_class": "tamper", "expire_after": 30, "icon": None, "platform": "binary_sensor"},
         "input_num": 1,
         "mqtt": {"payload_off": "OFF", "payload_on": "ON", "topic": "rpi2home-assistant/opto_input_1"},
@@ -160,6 +161,8 @@ i2c_optoisolated_inputs:
       device_class: tamper
       expire_after: 1000
       icon: mdi:check-circle
+    filter:
+      minimal_duration_sec: 3
 gpio_inputs:
   - name: radio_channel_a
     description: yet another test
@@ -213,6 +216,9 @@ def test_config_file_fully_specified_succeeds(tmpdir):
     assert x.get_optoisolated_input_config(1) == {
         "active_low": True,
         "description": "just a test",
+        "filter": {
+            "minimal_duration_sec": 3,
+        },
         "home_assistant": {
             "device_class": "tamper",
             "expire_after": 1000,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_config_file_using_defaults_succeeds(tmpdir):
     assert x.get_optoisolated_input_config(1) == {
         "active_low": True,
         "description": "opto_input_1",
-        "filter": {},
+        "filter": {"minimal_duration_sec": 0},
         "home_assistant": {"device_class": "tamper", "expire_after": 30, "icon": None, "platform": "binary_sensor"},
         "input_num": 1,
         "mqtt": {"payload_off": "OFF", "payload_on": "ON", "topic": "rpi2home-assistant/opto_input_1"},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_config_file_using_defaults_succeeds(tmpdir):
     assert x.get_optoisolated_input_config(1) == {
         "active_low": True,
         "description": "opto_input_1",
-        "filter": {"minimal_duration_sec": 0},
+        "filter": {"stability_threshold_sec": 0},
         "home_assistant": {"device_class": "tamper", "expire_after": 30, "icon": None, "platform": "binary_sensor"},
         "input_num": 1,
         "mqtt": {"payload_off": "OFF", "payload_on": "ON", "topic": "rpi2home-assistant/opto_input_1"},
@@ -162,7 +162,7 @@ i2c_optoisolated_inputs:
       expire_after: 1000
       icon: mdi:check-circle
     filter:
-      minimal_duration_sec: 3
+      stability_threshold_sec: 3
 gpio_inputs:
   - name: radio_channel_a
     description: yet another test
@@ -217,7 +217,7 @@ def test_config_file_fully_specified_succeeds(tmpdir):
         "active_low": True,
         "description": "just a test",
         "filter": {
-            "minimal_duration_sec": 3,
+            "stability_threshold_sec": 3,
         },
         "home_assistant": {
             "device_class": "tamper",

--- a/tests/test_integration_discovery.py
+++ b/tests/test_integration_discovery.py
@@ -18,7 +18,7 @@ EXPECTED_DISCOVERY_MSG_OUTPUT_1 = """
     "manufacturer": "github.com/f18m",
     "model": "rpi2home-assistant",
     "name": "integration-test-instance",
-    "sw_version": "2.1.1",
+    "sw_version": "__THIS_FIELD_IS_NOT_CHECKED__",
     "identifiers": [
       "rpi2home-assistant-integration-test-instance"
     ]
@@ -41,7 +41,7 @@ EXPECTED_DISCOVERY_MSG_OPTO_ISOLATED_INPUT_1 = """
     "manufacturer": "github.com/f18m",
     "model": "rpi2home-assistant",
     "name": "integration-test-instance",
-    "sw_version": "2.1.1",
+    "sw_version": "__THIS_FIELD_IS_NOT_CHECKED__",
     "identifiers": [
       "rpi2home-assistant-integration-test-instance"
     ]
@@ -89,6 +89,8 @@ def test_mqtt_discovery_messages():
             for topic_and_expected in topics_under_test:
                 t = topic_and_expected["topic_name"]
                 exp = topic_and_expected["expected_msg"]
+                expected_dict = json.loads(exp)
+
                 assert broker.get_messages_received_in_watched_topic(t) == attempt
 
                 config_msg = broker.get_last_payload_received_in_watched_topic(t)
@@ -99,8 +101,12 @@ def test_mqtt_discovery_messages():
                     container.print_logs()
                     assert False
 
+                # do not compare version numbers inside discovery messages... this is to avoid
+                # updating this testcase on every new release:
+                del config_dict["device"]["sw_version"]
+                del expected_dict["device"]["sw_version"]
+
                 # check also the contents of the discovery message:
-                expected_dict = json.loads(exp)
                 assert config_dict == expected_dict
 
                 print(f"The discovery message on topic [{t}] matches the expected content. Proceeding.")


### PR DESCRIPTION
This PR is adding a new filter.stability_threshold_sec optional parameter associated with opto-isolated inputs.
If this parameter is non-zero then the opto-isolated inputs apply an ad-hoc filtering rule and will publish to MQTT
only samples that are stable for more time than the configured threshold.

This PR is also fixing a couple of CI/CD issues:
* parallel instantation of multiple MosquittoContainers -- this was broken exposing the port 1883 to the host -- a random port must be exposed instead of a fixed one to allow parallel testing
* the test_integration_discovery.py was hardcoding a specific rpi2home-assistant version... remove version from expected dictionary validation

